### PR TITLE
dns: allow using dns-server as designate target

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -400,7 +400,7 @@ template "/etc/bind/named.conf" do
             allow_transfer: allow_transfer,
             ipaddress: admin_addr,
             ip6address: admin_addr6,
-            enable_designate: node[:dns][:enable_designate]
+            enable_designate: node[:dns][:enable_designate] && node[:dns][:master]
            )
   notifies :restart, "service[bind9]", :immediately
 end

--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -294,7 +294,8 @@ when "suse"
 end
 
 # We would like to bind service only to ip address from admin network
-admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+admin_network = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin")
+admin_addr = admin_network.address
 
 # Load up our default zones.  These never change.
 if node[:dns][:master]
@@ -353,6 +354,21 @@ template "/etc/bind/named.conf.crowbar" do
   notifies :reload, "service[bind9]"
 end
 
+if node[:dns][:enable_designate] && node[:dns][:master]
+  template "/etc/named.d/designate-rndc-access.conf" do
+    source "designate-rndc-access.conf.erb"
+    mode 0o640
+    owner "root"
+    group bindgroup
+    variables(
+      rndc_key: node[:dns][:designate_rndc_key],
+      master_ip: admin_network.address,
+      admin_subnet: admin_network.subnet
+    )
+    notifies :restart, "service[bind9]", :delayed
+  end
+end
+
 if node[:dns][:master]
   allow_transfer = node[:dns][:allow_transfer].to_a + node[:dns][:slave_ips].to_a
   allow_transfer = allow_transfer.uniq.sort.compact.delete_if { |n| n.empty? }
@@ -383,7 +399,9 @@ template "/etc/bind/named.conf" do
   variables(forwarders: node[:dns][:forwarders],
             allow_transfer: allow_transfer,
             ipaddress: admin_addr,
-            ip6address: admin_addr6)
+            ip6address: admin_addr6,
+            enable_designate: node[:dns][:enable_designate]
+           )
   notifies :restart, "service[bind9]", :immediately
 end
 

--- a/chef/cookbooks/bind9/templates/default/designate-rndc-access.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/designate-rndc-access.conf.erb
@@ -1,0 +1,11 @@
+key "designate-key" {
+    algorithm hmac-md5;
+    secret "<%= @rndc_key -%>";
+};
+
+controls {
+    # listen on the admin interface and
+    # allow access via the desgiante-key
+    # from ips of admin_subnet
+    inet <%= @master_ip -%> allow { <%= @admin_subnet -%>; } keys { designate-key; };
+};

--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -49,3 +49,6 @@ include "/etc/bind/named.conf.default-zones";
 include "/etc/bind/named.conf.crowbar";
 include "/etc/bind/named.conf.local";
 include "/etc/named.d/rndc-access.conf";
+<% if @enable_designate -%>
+include "/etc/named.d/designate-rndc-access.conf";
+<% end -%>

--- a/chef/data_bags/crowbar/migrate/dns/301_add_rndckey.rb
+++ b/chef/data_bags/crowbar/migrate/dns/301_add_rndckey.rb
@@ -1,0 +1,11 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  deployment["designate_rndc_key"] = template_deployment["designate_rndc_key"]
+  deployment["enable_designate"] = template_deployment["enable_designate"]
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attr.delete("designate_rndc_key") unless template_attrs.key("designate_rndc_key")
+  attr.delete("enable_designate") unless template_attrs.key("enable_designate")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-dns.json
+++ b/chef/data_bags/crowbar/template-dns.json
@@ -9,7 +9,9 @@
       "nameservers": [ ],
       "additional_search_domains": [ ],
       "records": { },
-      "auto_assign_server": true
+      "auto_assign_server": true,
+      "designate_rndc_key": "",
+      "enable_designate": false
     }
   },
   "deployment": {

--- a/chef/data_bags/crowbar/template-dns.schema
+++ b/chef/data_bags/crowbar/template-dns.schema
@@ -54,7 +54,9 @@
             "auto_assign_server": {
               "type": "bool",
               "required": true
-            }
+            },
+            "designate_rndc_key": { "type": "str", "required": false },
+            "enable_designate": { "type": "bool", "required": false }
           }
         }
       }


### PR DESCRIPTION
- added rndc key field to dns proposal
- based on value of enable_designate this key is checked to be base64
decodability, as expected by named
- a default key is pregnerated (512 bits)
- the designate barclamp will install this key on desginate-worker
nodes as these nodes need authoritative command on the dns-server to
create zones
-  syntax for the controls clause[1]

1 - http://www.zytrax.com/books/dns/ch7/controls.html